### PR TITLE
Fix ci failures

### DIFF
--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -6,6 +6,7 @@ jobs:
   industrial_ci:
     name: ROS ${{ matrix.ros_distro }} (${{ matrix.ros_repo }})
     strategy:
+      fail-fast: false
       matrix:
         ros_distro: [jazzy, rolling]
         ros_repo: [testing, main]

--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -18,3 +18,4 @@ jobs:
           ROS_DISTRO: ${{ matrix.ros_distro }}
           ROS_REPO: ${{ matrix.ros_repo }}
           UPSTREAM_WORKSPACE: kuka_rsi_driver.${{ matrix.ros_distro }}.repos -ros2_controllers/admittance_controller
+          UPSTREAM_CMAKE_ARGS: -DBUILD_TESTING:BOOL=Off

--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -17,4 +17,4 @@ jobs:
         env:
           ROS_DISTRO: ${{ matrix.ros_distro }}
           ROS_REPO: ${{ matrix.ros_repo }}
-          UPSTREAM_WORKSPACE: kuka_rsi_driver.${{ matrix.ros_distro }}.repos
+          UPSTREAM_WORKSPACE: kuka_rsi_driver.${{ matrix.ros_distro }}.repos -ros2_controllers/admittance_controller


### PR DESCRIPTION
Currently the CI fails while building admittance_controller in the upstream workspace, cancelling all other jobs. This PR allows all jobs to complete and excludes admittance controller from the build.