### PR TITLE
Pass through RSI signals

### DIFF
--- a/kuka_rsi_driver/CMakeLists.txt
+++ b/kuka_rsi_driver/CMakeLists.txt
@@ -55,6 +55,7 @@ target_sources(kuka_rsi_driver
     src/rsi_factory.cpp
     src/rsi_parser.cpp
     src/rsi.cpp
+    src/rsi_config.cpp
     src/rsi_writer.cpp
     src/udp_server.cpp
 )

--- a/kuka_rsi_driver/include/kuka_rsi_driver/control_thread.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/control_thread.h
@@ -55,9 +55,6 @@ class ControlThread
 {
 public:
   ControlThread(const RsiConfig& config,
-                const std::string& sentype,
-                const std::string& listen_address,
-                unsigned short listen_port,
                 ControlBuffer* control_buf,
                 RsiFactory* rsi_factory,
                 rclcpp::Logger log);

--- a/kuka_rsi_driver/include/kuka_rsi_driver/control_thread.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/control_thread.h
@@ -36,6 +36,7 @@
 #define KUKA_RSI_DRIVER_CONTROL_THREAD_H_INCLUDED
 
 #include "rsi.h"
+#include "rsi_config.h"
 #include "rsi_factory.h"
 #include "rsi_parser.h"
 #include "rsi_writer.h"
@@ -53,7 +54,8 @@ class ControlBuffer;
 class ControlThread
 {
 public:
-  ControlThread(const std::string& sentype,
+  ControlThread(const RsiConfig& config,
+                const std::string& sentype,
                 const std::string& listen_address,
                 unsigned short listen_port,
                 ControlBuffer* control_buf,

--- a/kuka_rsi_driver/include/kuka_rsi_driver/hardware_interface.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/hardware_interface.h
@@ -43,6 +43,7 @@
 #include "tracing.h"
 
 #include <hardware_interface/system_interface.hpp>
+#include <memory>
 #include <optional>
 #include <rclcpp_lifecycle/state.hpp>
 #include <vector>
@@ -73,7 +74,7 @@ public:
 private:
   void setState(const RsiState& state);
 
-  std::optional<RsiConfig> m_rsi_config;
+  std::shared_ptr<RsiConfig> m_rsi_config;
   std::optional<RsiFactory> m_rsi_factory;
   std::optional<ControlBuffer> m_control_buf;
   std::optional<ControlThread> m_control_thread;

--- a/kuka_rsi_driver/include/kuka_rsi_driver/hardware_interface.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/hardware_interface.h
@@ -38,6 +38,7 @@
 #include "control_buffer.h"
 #include "control_thread.h"
 #include "rsi.h"
+#include "rsi_config.h"
 #include "rsi_factory.h"
 #include "tracing.h"
 
@@ -72,13 +73,7 @@ public:
 private:
   void setState(const RsiState& state);
 
-  std::vector<std::string> m_joint_command_pos_ifaces;
-  std::vector<std::string> m_joint_state_pos_ifaces;
-  std::vector<std::string> m_joint_state_eff_ifaces;
-  std::vector<std::string> m_sensor_tcp_state_ifaces;
-  std::string m_gpio_robot_state_iface;
-  std::string m_gpio_speed_scaling_state_iface;
-
+  std::optional<InterfaceConfig> m_interface_config;
   std::optional<RsiFactory> m_rsi_factory;
   std::optional<ControlBuffer> m_control_buf;
   std::optional<ControlThread> m_control_thread;

--- a/kuka_rsi_driver/include/kuka_rsi_driver/hardware_interface.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/hardware_interface.h
@@ -73,7 +73,7 @@ public:
 private:
   void setState(const RsiState& state);
 
-  std::optional<InterfaceConfig> m_interface_config;
+  std::optional<RsiConfig> m_rsi_config;
   std::optional<RsiFactory> m_rsi_factory;
   std::optional<ControlBuffer> m_control_buf;
   std::optional<ControlThread> m_control_thread;

--- a/kuka_rsi_driver/include/kuka_rsi_driver/rsi.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/rsi.h
@@ -121,11 +121,14 @@ struct RsiPassthrough
   /*! \brief Pre-Allocate passthrough storage of given size
    *
    * \param num_bool Number of boolean values to pre-allocate
+   * \param num_double Number of double values to pre-allocate
    */
-  explicit RsiPassthrough(std::size_t num_bool);
+  explicit RsiPassthrough(std::size_t num_bool, std::size_t num_double);
 
   //! Passed-through boolean values
   std::vector<bool> values_bool;
+  //! Passed-through double values
+  std::vector<double> values_double;
 };
 
 class RsiState
@@ -134,8 +137,9 @@ public:
   /*! \brief Pre-Allocate a new state object
    *
    * \param num_passthrough_bool Number of boolean passthrough values to pre-allocate
+   * \param num_passthrough_double Number of double passthrough values to pre-allocate
    */
-  explicit RsiState(std::size_t num_passthrough_bool);
+  explicit RsiState(std::size_t num_passthrough_bool, std::size_t num_passthrough_double);
 
   JointArray axis_actual_pos;
   JointArray axis_setpoint_pos;
@@ -159,7 +163,12 @@ public:
 class RsiCommand
 {
 public:
-  explicit RsiCommand(std::size_t num_passthrough_bool);
+  /*! \brief Pre-Allocate a new command object
+   *
+   * \param num_passthrough_bool Number of boolean passthrough values to pre-allocate
+   * \param num_passthrough_double Number of double passthrough values to pre-allocate
+   */
+  explicit RsiCommand(std::size_t num_passthrough_bool, std::size_t num_passthrough_double);
 
   std::chrono::steady_clock::time_point write_time;
 

--- a/kuka_rsi_driver/include/kuka_rsi_driver/rsi.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/rsi.h
@@ -159,11 +159,14 @@ public:
 class RsiCommand
 {
 public:
-  RsiCommand();
+  explicit RsiCommand(std::size_t num_passthrough_bool);
 
   std::chrono::steady_clock::time_point write_time;
 
   JointArray axis_command_pos;
+
+  //! Additional values that are directly tunneled from command interfaces to RSI attributes
+  RsiPassthrough passthrough;
 
 private:
 };

--- a/kuka_rsi_driver/include/kuka_rsi_driver/rsi.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/rsi.h
@@ -122,13 +122,16 @@ struct RsiPassthrough
    *
    * \param num_bool Number of boolean values to pre-allocate
    * \param num_double Number of double values to pre-allocate
+   * \param num_long Number of long values to pre-allocate
    */
-  explicit RsiPassthrough(std::size_t num_bool, std::size_t num_double);
+  explicit RsiPassthrough(std::size_t num_bool, std::size_t num_double, std::size_t num_long);
 
   //! Passed-through boolean values
   std::vector<bool> values_bool;
   //! Passed-through double values
   std::vector<double> values_double;
+  //! Passed-through long values
+  std::vector<std::uint64_t> values_long;
 };
 
 class RsiState
@@ -138,8 +141,11 @@ public:
    *
    * \param num_passthrough_bool Number of boolean passthrough values to pre-allocate
    * \param num_passthrough_double Number of double passthrough values to pre-allocate
+   * \param num_passthrough_long Number of long passthrough values to pre-allocate
    */
-  explicit RsiState(std::size_t num_passthrough_bool, std::size_t num_passthrough_double);
+  explicit RsiState(std::size_t num_passthrough_bool,
+                    std::size_t num_passthrough_double,
+                    std::size_t num_passthrough_long);
 
   JointArray axis_actual_pos;
   JointArray axis_setpoint_pos;
@@ -167,8 +173,11 @@ public:
    *
    * \param num_passthrough_bool Number of boolean passthrough values to pre-allocate
    * \param num_passthrough_double Number of double passthrough values to pre-allocate
+   * \param num_passthrough_long Number of long passthrough values to pre-allocate
    */
-  explicit RsiCommand(std::size_t num_passthrough_bool, std::size_t num_passthrough_double);
+  explicit RsiCommand(std::size_t num_passthrough_bool,
+                      std::size_t num_passthrough_double,
+                      std::size_t num_passthrough_long);
 
   std::chrono::steady_clock::time_point write_time;
 

--- a/kuka_rsi_driver/include/kuka_rsi_driver/rsi.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/rsi.h
@@ -38,6 +38,7 @@
 #include <array>
 #include <chrono>
 #include <cstdint>
+#include <vector>
 
 namespace kuka_rsi_driver {
 
@@ -113,10 +114,28 @@ enum class ProgramStatus : std::uint8_t
   STOPPED = 4
 };
 
+/*! \brief Values that are transparently tunneled between interfaces and RSI attributes
+ */
+struct RsiPassthrough
+{
+  /*! \brief Pre-Allocate passthrough storage of given size
+   *
+   * \param num_bool Number of boolean values to pre-allocate
+   */
+  explicit RsiPassthrough(std::size_t num_bool);
+
+  //! Passed-through boolean values
+  std::vector<bool> values_bool;
+};
+
 class RsiState
 {
 public:
-  explicit RsiState();
+  /*! \brief Pre-Allocate a new state object
+   *
+   * \param num_passthrough_bool Number of boolean passthrough values to pre-allocate
+   */
+  explicit RsiState(std::size_t num_passthrough_bool);
 
   JointArray axis_actual_pos;
   JointArray axis_setpoint_pos;
@@ -132,6 +151,9 @@ public:
   double speed_scaling;
 
   ProgramStatus program_status;
+
+  //! Additional values that are directly tunneled from RSI attributes to state interfaces
+  RsiPassthrough passthrough;
 };
 
 class RsiCommand

--- a/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
@@ -38,8 +38,9 @@
 #include <array>
 #include <hardware_interface/hardware_info.hpp>
 #include <rclcpp/logger.hpp>
+#include <span>
 #include <string>
-#include <vector>
+#include <utility>
 
 namespace kuka_rsi_driver {
 
@@ -148,6 +149,10 @@ private:
                                     const std::string& name) const;
 
   void parsePassthrough(const hardware_interface::ComponentInfo& component);
+  std::pair<std::vector<InterfaceIndex>, RsiTag>
+  parseInterfaces(std::span<const hardware_interface::InterfaceInfo> interfaces,
+                  const hardware_interface::ComponentInfo& component,
+                  TransmissionConfig& transmission_config) const;
 
   void verifyComponent(const hardware_interface::ComponentInfo& component,
                        const std::string& component_function,

--- a/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
@@ -96,6 +96,18 @@ public:
    */
   RsiConfig(const hardware_interface::HardwareInfo& info);
 
+  /*! \brief SENTYPE specified in RSI messages
+   */
+  const std::string& sentype() const;
+
+  /*! \brief Address to listen to for RSI messages
+   */
+  const std::string& listenAddress() const;
+
+  /*! \brief Port to listen to for RSI messages
+   */
+  unsigned short listenPort() const;
+
   /*! \brief Access ros2_control interface definition
    *
    * \returns Interfaces used for this RSI session
@@ -109,12 +121,19 @@ public:
   const TransmissionConfig& receiveTransmissionConfig() const;
 
 private:
+  std::string requiredHardwareParam(const hardware_interface::HardwareInfo& info,
+                                    const std::string& name) const;
+
   void parsePassthrough(const hardware_interface::ComponentInfo& component);
 
   void verifyComponent(const hardware_interface::ComponentInfo& component,
                        const std::string& component_function,
                        const std::vector<std::string>& expected_state_interfaces,
                        const std::vector<std::string>& expected_command_interfaces) const;
+
+  std::string m_sentype;
+  std::string m_listen_address;
+  unsigned short m_listen_port;
 
   InterfaceConfig m_interface_config;
 

--- a/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
@@ -1,0 +1,97 @@
+// Copyright 2025 FZI Forschungszentrum Informatik
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/*!\file kuka_rsi_driver/rsi_config.h
+ * \brief Definition of mappings between interfaces, internal structures and XML entries
+ *
+ * \author  Robert Wilbrandt wilbrandt@fzi.de
+ * \date    2025-03-06
+ */
+#ifndef KUKA_RSI_DRIVER_RSI_CONFIG_H_INCLUDED
+#define KUKA_RSI_DRIVER_RSI_CONFIG_H_INCLUDED
+
+#include <hardware_interface/hardware_info.hpp>
+#include <string>
+#include <vector>
+
+namespace kuka_rsi_driver {
+
+/*! \brief Definition of used state and command interfaces
+ */
+class InterfaceConfig
+{
+public:
+  /*! \brief Create config based on interface specification
+   *
+   * \param info Hardware information from URDF
+   */
+  InterfaceConfig(const hardware_interface::HardwareInfo& info);
+
+  /*! \brief Get the fully qualified names of all joint state position interfaces
+   */
+  const std::vector<std::string>& jointStatePositionInterfaces() const;
+
+  /*! \brief Get the fully qualified names of all joint state effort interfaces
+   */
+  const std::vector<std::string>& jointStateEffortInterfaces() const;
+
+  /*! \brief Get the fully qualified names of all joint command position interfaces
+   */
+  const std::vector<std::string>& jointCommandPositionInterfaces() const;
+
+  /*! \brief Get the fully qualified names of all sensor interfaces for the TCP pose
+   */
+  const std::vector<std::string>& tcpSensorInterfaces() const;
+
+  /*! \brief Get the fully qualified name of the robot state state interface
+   */
+  const std::string& robotStateInterface() const;
+
+  /*! \brief Get the fully qualified names of the speed scaling state interface
+   */
+  const std::string& speedScalingInterface() const;
+
+private:
+  void verifyComponent(const hardware_interface::ComponentInfo& component,
+                       const std::string& component_function,
+                       const std::vector<std::string>& expected_state_interfaces,
+                       const std::vector<std::string>& expected_command_interfaces) const;
+
+  std::vector<std::string> m_joint_state_position_interfaces;
+  std::vector<std::string> m_joint_state_effort_interfaces;
+  std::vector<std::string> m_joint_command_position_interfaces;
+
+  std::vector<std::string> m_tcp_sensor_interfaces;
+
+  std::string m_robot_state_interface;
+  std::string m_speed_scaling_interface;
+};
+
+} // namespace kuka_rsi_driver
+
+#endif // KUKA_RSI_DRIVER_RSI_CONFIG_H_INCLUDED

--- a/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
@@ -43,6 +43,16 @@
 
 namespace kuka_rsi_driver {
 
+/*! \brief Mapping between internal structure and interface
+ */
+struct InterfaceIndex
+{
+  //! Index in RSI state/command structure
+  std::size_t index;
+  //! Fully qualified interface name
+  std::string name;
+};
+
 /*! \brief Definition of all state and command interfaces
  */
 struct InterfaceConfig
@@ -61,6 +71,9 @@ struct InterfaceConfig
   std::string robot_state_state_interface;
   //! Fully qualified name of speed scaling state interface
   std::string speed_scaling_state_interface;
+
+  //! All directly passed-through interfaces
+  std::vector<InterfaceIndex> passthrough_state_interfaces;
 };
 
 struct RsiIndex

--- a/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
@@ -37,6 +37,7 @@
 
 #include <array>
 #include <hardware_interface/hardware_info.hpp>
+#include <rclcpp/logger.hpp>
 #include <string>
 #include <vector>
 
@@ -93,8 +94,9 @@ public:
   /*! \brief Create new config for a given hardware info
    *
    * \param info Hardware info to extract interfaces and mappings from
+   * \param log Logger to use
    */
-  RsiConfig(const hardware_interface::HardwareInfo& info);
+  RsiConfig(const hardware_interface::HardwareInfo& info, rclcpp::Logger log);
 
   /*! \brief SENTYPE specified in RSI messages
    */
@@ -130,6 +132,8 @@ private:
                        const std::string& component_function,
                        const std::vector<std::string>& expected_state_interfaces,
                        const std::vector<std::string>& expected_command_interfaces) const;
+
+  rclcpp::Logger m_log;
 
   std::string m_sentype;
   std::string m_listen_address;

--- a/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
@@ -62,12 +62,37 @@ struct InterfaceConfig
   std::string speed_scaling_state_interface;
 };
 
+/*! \brief Definition of signals in one communication direction
+ */
+struct TransmissionConfig
+{
+  explicit TransmissionConfig();
+
+  std::size_t num_passthrough_bool;
+};
+
+/*! \brief Definition of mapping between interfaces and RSI communication objects
+ */
 class RsiConfig
 {
 public:
+  /*! \brief Create new config for a given hardware info
+   *
+   * \param info Hardware info to extract interfaces and mappings from
+   */
   RsiConfig(const hardware_interface::HardwareInfo& info);
 
+  /*! \brief Access ros2_control interface definition
+   *
+   * \returns Interfaces used for this RSI session
+   */
   const InterfaceConfig& interfaceConfig() const;
+
+  /*! \brief RSI transmission config for signal reception
+   *
+   * \returns RSI signal reception transmission config
+   */
+  const TransmissionConfig& receiveTransmissionConfig() const;
 
 private:
   void verifyComponent(const hardware_interface::ComponentInfo& component,
@@ -76,6 +101,8 @@ private:
                        const std::vector<std::string>& expected_command_interfaces) const;
 
   InterfaceConfig m_interface_config;
+
+  TransmissionConfig m_receive_config;
 };
 
 } // namespace kuka_rsi_driver

--- a/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
@@ -49,7 +49,8 @@ namespace kuka_rsi_driver {
 enum class DataType
 {
   BOOL,
-  DOUBLE
+  DOUBLE,
+  LONG
 };
 
 /*! \brief Mapping between internal structure and interface
@@ -112,6 +113,7 @@ struct TransmissionConfig
 
   std::size_t num_passthrough_bool;
   std::size_t num_passthrough_double;
+  std::size_t num_passthrough_long;
 };
 
 /*! \brief Definition of mapping between interfaces and RSI communication objects

--- a/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
@@ -62,11 +62,25 @@ struct InterfaceConfig
   std::string speed_scaling_state_interface;
 };
 
+struct RsiIndex
+{
+  std::string name;
+  std::size_t index;
+};
+
+struct RsiTag
+{
+  std::string name;
+  std::vector<RsiIndex> indices;
+};
+
 /*! \brief Definition of signals in one communication direction
  */
 struct TransmissionConfig
 {
   explicit TransmissionConfig();
+
+  std::vector<RsiTag> tags;
 
   std::size_t num_passthrough_bool;
 };
@@ -95,6 +109,8 @@ public:
   const TransmissionConfig& receiveTransmissionConfig() const;
 
 private:
+  void parsePassthrough(const hardware_interface::ComponentInfo& component);
+
   void verifyComponent(const hardware_interface::ComponentInfo& component,
                        const std::string& component_function,
                        const std::vector<std::string>& expected_state_interfaces,

--- a/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
@@ -44,6 +44,14 @@
 
 namespace kuka_rsi_driver {
 
+/*! \brief Available data types that can be passed through transparently between RSI and interfaces
+ */
+enum class DataType
+{
+  BOOL,
+  DOUBLE
+};
+
 /*! \brief Mapping between internal structure and interface
  */
 struct InterfaceIndex
@@ -52,6 +60,8 @@ struct InterfaceIndex
   std::size_t index;
   //! Fully qualified interface name
   std::string name;
+  //! Data type
+  DataType type;
 };
 
 /*! \brief Definition of all state and command interfaces
@@ -83,6 +93,7 @@ struct RsiIndex
 {
   std::string name;
   std::size_t index;
+  DataType type;
 };
 
 struct RsiTag
@@ -100,6 +111,7 @@ struct TransmissionConfig
   std::vector<RsiTag> tags;
 
   std::size_t num_passthrough_bool;
+  std::size_t num_passthrough_double;
 };
 
 /*! \brief Definition of mapping between interfaces and RSI communication objects

--- a/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
@@ -72,8 +72,10 @@ struct InterfaceConfig
   //! Fully qualified name of speed scaling state interface
   std::string speed_scaling_state_interface;
 
-  //! All directly passed-through interfaces
+  //! All directly passed-through state interfaces
   std::vector<InterfaceIndex> passthrough_state_interfaces;
+  //! All directly passed-through command interfaces
+  std::vector<InterfaceIndex> passthrough_command_interfaces;
 };
 
 struct RsiIndex
@@ -135,6 +137,12 @@ public:
    */
   const TransmissionConfig& receiveTransmissionConfig() const;
 
+  /*! \brief RSI transmission config for signal sending
+   *
+   * \returns RSI signal sending transmission config
+   */
+  const TransmissionConfig& sendTransmissionConfig() const;
+
 private:
   std::string requiredHardwareParam(const hardware_interface::HardwareInfo& info,
                                     const std::string& name) const;
@@ -155,6 +163,7 @@ private:
   InterfaceConfig m_interface_config;
 
   TransmissionConfig m_receive_config;
+  TransmissionConfig m_send_config;
 };
 
 } // namespace kuka_rsi_driver

--- a/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/rsi_config.h
@@ -35,46 +35,39 @@
 #ifndef KUKA_RSI_DRIVER_RSI_CONFIG_H_INCLUDED
 #define KUKA_RSI_DRIVER_RSI_CONFIG_H_INCLUDED
 
+#include <array>
 #include <hardware_interface/hardware_info.hpp>
 #include <string>
 #include <vector>
 
 namespace kuka_rsi_driver {
 
-/*! \brief Definition of used state and command interfaces
+/*! \brief Definition of all state and command interfaces
  */
-class InterfaceConfig
+struct InterfaceConfig
+{
+  //! Fully qualified names of all joint position state interfaces
+  std::vector<std::string> joint_position_state_interfaces;
+  //! Fully qualified names of all joint effort state interfaces
+  std::vector<std::string> joint_effort_state_interfaces;
+  //! Fully qualified names of all joint position command interfaces
+  std::vector<std::string> joint_position_command_interfaces;
+
+  //! Fully qualified names of all tcp sensor state interfaces
+  std::array<std::string, 7> tcp_state_interfaces;
+
+  //! Fully qualified name of robot state state interface
+  std::string robot_state_state_interface;
+  //! Fully qualified name of speed scaling state interface
+  std::string speed_scaling_state_interface;
+};
+
+class RsiConfig
 {
 public:
-  /*! \brief Create config based on interface specification
-   *
-   * \param info Hardware information from URDF
-   */
-  InterfaceConfig(const hardware_interface::HardwareInfo& info);
+  RsiConfig(const hardware_interface::HardwareInfo& info);
 
-  /*! \brief Get the fully qualified names of all joint state position interfaces
-   */
-  const std::vector<std::string>& jointStatePositionInterfaces() const;
-
-  /*! \brief Get the fully qualified names of all joint state effort interfaces
-   */
-  const std::vector<std::string>& jointStateEffortInterfaces() const;
-
-  /*! \brief Get the fully qualified names of all joint command position interfaces
-   */
-  const std::vector<std::string>& jointCommandPositionInterfaces() const;
-
-  /*! \brief Get the fully qualified names of all sensor interfaces for the TCP pose
-   */
-  const std::vector<std::string>& tcpSensorInterfaces() const;
-
-  /*! \brief Get the fully qualified name of the robot state state interface
-   */
-  const std::string& robotStateInterface() const;
-
-  /*! \brief Get the fully qualified names of the speed scaling state interface
-   */
-  const std::string& speedScalingInterface() const;
+  const InterfaceConfig& interfaceConfig() const;
 
 private:
   void verifyComponent(const hardware_interface::ComponentInfo& component,
@@ -82,14 +75,7 @@ private:
                        const std::vector<std::string>& expected_state_interfaces,
                        const std::vector<std::string>& expected_command_interfaces) const;
 
-  std::vector<std::string> m_joint_state_position_interfaces;
-  std::vector<std::string> m_joint_state_effort_interfaces;
-  std::vector<std::string> m_joint_command_position_interfaces;
-
-  std::vector<std::string> m_tcp_sensor_interfaces;
-
-  std::string m_robot_state_interface;
-  std::string m_speed_scaling_interface;
+  InterfaceConfig m_interface_config;
 };
 
 } // namespace kuka_rsi_driver

--- a/kuka_rsi_driver/include/kuka_rsi_driver/rsi_factory.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/rsi_factory.h
@@ -47,7 +47,7 @@ class RsiFactory
 {
 public:
   explicit RsiFactory(std::size_t cyclic_buf_size = 1024);
-  explicit RsiFactory(const RsiConfig& config, std::size_t cyclic_buf_size = 1024);
+  explicit RsiFactory(std::shared_ptr<RsiConfig> config, std::size_t cyclic_buf_size = 1024);
 
   RsiCommand createCommand() const;
   std::shared_ptr<RsiCommand> createCyclicCommand();
@@ -55,6 +55,8 @@ public:
   std::shared_ptr<RsiState> createCyclicState();
 
 private:
+  std::shared_ptr<RsiConfig> m_rsi_config;
+
   std::vector<std::shared_ptr<RsiCommand>> m_cmd_buf;
   std::size_t m_cmd_i;
 

--- a/kuka_rsi_driver/include/kuka_rsi_driver/rsi_factory.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/rsi_factory.h
@@ -36,6 +36,7 @@
 #define KUKA_RSI_DRIVER_RSI_FACTORY_H_INCLUDED
 
 #include "rsi.h"
+#include "rsi_config.h"
 
 #include <memory>
 #include <vector>
@@ -46,6 +47,7 @@ class RsiFactory
 {
 public:
   explicit RsiFactory(std::size_t cyclic_buf_size = 1024);
+  explicit RsiFactory(const RsiConfig& config, std::size_t cyclic_buf_size = 1024);
 
   RsiCommand createCommand() const;
   std::shared_ptr<RsiCommand> createCyclicCommand();

--- a/kuka_rsi_driver/include/kuka_rsi_driver/rsi_parser.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/rsi_parser.h
@@ -36,6 +36,7 @@
 #define KUKA_RSI_DRIVER_RSI_PARSER_H_INCLUDED
 
 #include "rsi.h"
+#include "rsi_config.h"
 #include "rsi_factory.h"
 
 #include <boost/pool/pool.hpp>
@@ -211,11 +212,15 @@ class RsiParser
 public:
   /*! \brief Create a new parser
    *
-   * \param log Logger to use.
+   * \param config Configuration of all additional tags
    * \param rsi_factory Factory for pre-allocated RSI states
+   * \param log Logger to use.
    * \param buf_size Size of parsing buffer to allocate. Only input within this size can be parsed.
    */
-  explicit RsiParser(rclcpp::Logger log, RsiFactory* rsi_factory, std::size_t buf_size = 1024);
+  explicit RsiParser(const TransmissionConfig& config,
+                     RsiFactory* rsi_factory,
+                     rclcpp::Logger log,
+                     std::size_t buf_size = 1024);
 
   RsiParser(const RsiParser&)            = delete;
   RsiParser& operator=(const RsiParser&) = delete;

--- a/kuka_rsi_driver/include/kuka_rsi_driver/rsi_writer.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/rsi_writer.h
@@ -36,6 +36,7 @@
 #define KUKA_RSI_DRIVER_RSI_WRITER_H_INCLUDED
 
 #include "rsi.h"
+#include "rsi_config.h"
 
 #include <cstdint>
 #include <rclcpp/logger.hpp>
@@ -72,7 +73,10 @@ private:
 class RsiWriter
 {
 public:
-  RsiWriter(const std::string& sentype, rclcpp::Logger log, std::size_t buf_size = 1024);
+  RsiWriter(const std::string& sentype,
+            const TransmissionConfig& config,
+            rclcpp::Logger log,
+            std::size_t buf_size = 1024);
 
   [[nodiscard]] std::size_t
   writeCommand(const RsiCommand& cmd, std::size_t ipoc, std::span<char> target);
@@ -81,6 +85,7 @@ private:
   rclcpp::Logger m_log;
 
   std::string m_sentype;
+  TransmissionConfig m_config;
 
   TextWriter m_writer;
 };

--- a/kuka_rsi_driver/src/control_thread.cpp
+++ b/kuka_rsi_driver/src/control_thread.cpp
@@ -48,7 +48,7 @@ ControlThread::ControlThread(const RsiConfig& config,
   : m_log{std::move(log)}
   , m_udp_server{config.listenAddress(), config.listenPort(), std::chrono::milliseconds{1}}
   , m_rsi_parser{config.receiveTransmissionConfig(), rsi_factory, m_log}
-  , m_rsi_writer{config.sentype(), m_log}
+  , m_rsi_writer{config.sentype(), config.sendTransmissionConfig(), m_log}
   , m_control_buf{control_buf}
   , m_initial_cmd{rsi_factory->createCommand()}
   , m_rsi_cmd{rsi_factory->createCommand()}
@@ -143,6 +143,10 @@ void ControlThread::run()
       for (std::size_t i = 0; i < 6; ++i)
       {
         m_rsi_cmd.axis_command_pos[i] = cmd->axis_command_pos[i] - (*m_cmd_offset)[i];
+      }
+      for (std::size_t i = 0; i < cmd->passthrough.values_bool.size(); ++i)
+      {
+        m_rsi_cmd.passthrough.values_bool[i] = cmd->passthrough.values_bool[i];
       }
 
       KUKA_RSI_DRIVER_TRACEPOINT(rsi_packet_sent,

--- a/kuka_rsi_driver/src/control_thread.cpp
+++ b/kuka_rsi_driver/src/control_thread.cpp
@@ -148,6 +148,10 @@ void ControlThread::run()
       {
         m_rsi_cmd.passthrough.values_bool[i] = cmd->passthrough.values_bool[i];
       }
+      for (std::size_t i = 0; i < cmd->passthrough.values_double.size(); ++i)
+      {
+        m_rsi_cmd.passthrough.values_double[i] = cmd->passthrough.values_double[i];
+      }
 
       KUKA_RSI_DRIVER_TRACEPOINT(rsi_packet_sent,
                                  rsi_state->ipoc,

--- a/kuka_rsi_driver/src/control_thread.cpp
+++ b/kuka_rsi_driver/src/control_thread.cpp
@@ -152,6 +152,10 @@ void ControlThread::run()
       {
         m_rsi_cmd.passthrough.values_double[i] = cmd->passthrough.values_double[i];
       }
+      for (std::size_t i = 0; i < cmd->passthrough.values_long.size(); ++i)
+      {
+        m_rsi_cmd.passthrough.values_long[i] = cmd->passthrough.values_long[i];
+      }
 
       KUKA_RSI_DRIVER_TRACEPOINT(rsi_packet_sent,
                                  rsi_state->ipoc,

--- a/kuka_rsi_driver/src/control_thread.cpp
+++ b/kuka_rsi_driver/src/control_thread.cpp
@@ -42,23 +42,23 @@
 namespace kuka_rsi_driver {
 
 ControlThread::ControlThread(const RsiConfig& config,
-                             const std::string& sentype,
-                             const std::string& listen_address,
-                             unsigned short listen_port,
                              ControlBuffer* control_buf,
                              RsiFactory* rsi_factory,
                              rclcpp::Logger log)
   : m_log{std::move(log)}
-  , m_udp_server{listen_address, listen_port, std::chrono::milliseconds{1}}
+  , m_udp_server{config.listenAddress(), config.listenPort(), std::chrono::milliseconds{1}}
   , m_rsi_parser{config.receiveTransmissionConfig(), rsi_factory, m_log}
-  , m_rsi_writer{sentype, m_log}
+  , m_rsi_writer{config.sentype(), m_log}
   , m_control_buf{control_buf}
   , m_initial_cmd{rsi_factory->createCommand()}
   , m_rsi_cmd{rsi_factory->createCommand()}
 {
   m_write_buf.resize(1024);
 
-  RCLCPP_INFO(m_log, "Created UDP server listening on %s:%hu", listen_address.c_str(), listen_port);
+  RCLCPP_INFO(m_log,
+              "Created UDP server listening on %s:%hu",
+              config.listenAddress().c_str(),
+              config.listenPort());
 }
 
 ControlThread::~ControlThread()

--- a/kuka_rsi_driver/src/control_thread.cpp
+++ b/kuka_rsi_driver/src/control_thread.cpp
@@ -41,7 +41,8 @@
 
 namespace kuka_rsi_driver {
 
-ControlThread::ControlThread(const std::string& sentype,
+ControlThread::ControlThread(const RsiConfig& config,
+                             const std::string& sentype,
                              const std::string& listen_address,
                              unsigned short listen_port,
                              ControlBuffer* control_buf,
@@ -49,7 +50,7 @@ ControlThread::ControlThread(const std::string& sentype,
                              rclcpp::Logger log)
   : m_log{std::move(log)}
   , m_udp_server{listen_address, listen_port, std::chrono::milliseconds{1}}
-  , m_rsi_parser{m_log, rsi_factory}
+  , m_rsi_parser{config.receiveTransmissionConfig(), rsi_factory, m_log}
   , m_rsi_writer{sentype, m_log}
   , m_control_buf{control_buf}
   , m_initial_cmd{rsi_factory->createCommand()}

--- a/kuka_rsi_driver/src/hardware_interface.cpp
+++ b/kuka_rsi_driver/src/hardware_interface.cpp
@@ -56,7 +56,7 @@ KukaRsiHardwareInterface::on_init(const hardware_interface::HardwareInfo& info)
   {
     m_rsi_config.emplace(info_);
 
-    m_rsi_factory.emplace();
+    m_rsi_factory.emplace(*m_rsi_config);
     m_control_buf.emplace(*m_rsi_factory);
 
     const auto listen_address = info_.hardware_parameters["listen_address"];
@@ -75,7 +75,8 @@ KukaRsiHardwareInterface::on_init(const hardware_interface::HardwareInfo& info)
       sentype = sentype_it->second;
     }
 
-    m_control_thread.emplace(sentype,
+    m_control_thread.emplace(*m_rsi_config,
+                             sentype,
                              listen_address,
                              std::stoi(listen_port),
                              &(*m_control_buf),

--- a/kuka_rsi_driver/src/hardware_interface.cpp
+++ b/kuka_rsi_driver/src/hardware_interface.cpp
@@ -212,6 +212,13 @@ void KukaRsiHardwareInterface::setState(const RsiState& state)
   {
     set_state(interface_config.speed_scaling_state_interface, 0.0);
   }
+
+  // Passthrough interfaces
+  for (const auto& passthrough_index : interface_config.passthrough_state_interfaces)
+  {
+    set_state(passthrough_index.name,
+              state.passthrough.values_bool[passthrough_index.index] ? 1.0 : 0.0);
+  }
 }
 
 } // namespace kuka_rsi_driver

--- a/kuka_rsi_driver/src/hardware_interface.cpp
+++ b/kuka_rsi_driver/src/hardware_interface.cpp
@@ -54,7 +54,7 @@ KukaRsiHardwareInterface::on_init(const hardware_interface::HardwareInfo& info)
 
   try
   {
-    m_rsi_config.emplace(info_);
+    m_rsi_config.emplace(info_, get_logger());
 
     m_rsi_factory.emplace(*m_rsi_config);
     m_control_buf.emplace(*m_rsi_factory);

--- a/kuka_rsi_driver/src/hardware_interface.cpp
+++ b/kuka_rsi_driver/src/hardware_interface.cpp
@@ -59,29 +59,7 @@ KukaRsiHardwareInterface::on_init(const hardware_interface::HardwareInfo& info)
     m_rsi_factory.emplace(*m_rsi_config);
     m_control_buf.emplace(*m_rsi_factory);
 
-    const auto listen_address = info_.hardware_parameters["listen_address"];
-    const auto listen_port    = info_.hardware_parameters["listen_port"];
-
-    if (listen_address.empty() || listen_port.empty())
-    {
-      throw std::runtime_error{"Hardware interface requires parameters listen_address and "
-                               "listen_port for RSI communication"};
-    }
-
-    std::string sentype   = "KukaRsiDriver";
-    const auto sentype_it = info_.hardware_parameters.find("sentype");
-    if (sentype_it != info_.hardware_parameters.end())
-    {
-      sentype = sentype_it->second;
-    }
-
-    m_control_thread.emplace(*m_rsi_config,
-                             sentype,
-                             listen_address,
-                             std::stoi(listen_port),
-                             &(*m_control_buf),
-                             &(*m_rsi_factory),
-                             get_logger());
+    m_control_thread.emplace(*m_rsi_config, &(*m_control_buf), &(*m_rsi_factory), get_logger());
   }
   catch (std::exception& ex)
   {

--- a/kuka_rsi_driver/src/hardware_interface.cpp
+++ b/kuka_rsi_driver/src/hardware_interface.cpp
@@ -99,6 +99,13 @@ KukaRsiHardwareInterface::on_configure(const rclcpp_lifecycle::State& previous_s
         set_command(joint_position_command_interfaces[i], state->axis_actual_pos[i] * M_PI / 180.);
       }
 
+      // Passthrough interfaces
+      const auto& interface_config = m_rsi_config->interfaceConfig();
+      for (const auto& passthrough_index : interface_config.passthrough_command_interfaces)
+      {
+        set_command(passthrough_index.name, 0.0);
+      }
+
       m_control_buf->zeroOffsets();
 
       RCLCPP_INFO(get_logger(), "Initialized RSI communication");

--- a/kuka_rsi_driver/src/hardware_interface.cpp
+++ b/kuka_rsi_driver/src/hardware_interface.cpp
@@ -35,6 +35,7 @@
 
 #include "kuka_rsi_driver/tracing.h"
 
+#include <bit>
 #include <hardware_interface/types/hardware_interface_type_values.hpp>
 #include <lifecycle_msgs/msg/state.hpp>
 #include <limits>
@@ -178,6 +179,11 @@ hardware_interface::return_type KukaRsiHardwareInterface::write(const rclcpp::Ti
             get_command(passthrough_index.name);
           break;
 
+        case DataType::LONG:
+          cmd->passthrough.values_long[passthrough_index.index] =
+            std::bit_cast<std::uint64_t>(get_command(passthrough_index.name));
+          break;
+
         default:
           throw std::runtime_error{"Invalid data type"};
       }
@@ -246,6 +252,11 @@ void KukaRsiHardwareInterface::setState(const RsiState& state)
 
       case DataType::DOUBLE:
         set_state(passthrough_index.name, state.passthrough.values_double[passthrough_index.index]);
+        break;
+
+      case DataType::LONG:
+        set_state(passthrough_index.name,
+                  std::bit_cast<double>(state.passthrough.values_long[passthrough_index.index]));
         break;
 
       default:

--- a/kuka_rsi_driver/src/hardware_interface.cpp
+++ b/kuka_rsi_driver/src/hardware_interface.cpp
@@ -166,8 +166,21 @@ hardware_interface::return_type KukaRsiHardwareInterface::write(const rclcpp::Ti
     const auto& interface_config = m_rsi_config->interfaceConfig();
     for (const auto& passthrough_index : interface_config.passthrough_command_interfaces)
     {
-      cmd->passthrough.values_bool[passthrough_index.index] =
-        get_command(passthrough_index.name) == 1.0 ? true : false;
+      switch (passthrough_index.type)
+      {
+        case DataType::BOOL:
+          cmd->passthrough.values_bool[passthrough_index.index] =
+            get_command(passthrough_index.name) == 1.0 ? true : false;
+          break;
+
+        case DataType::DOUBLE:
+          cmd->passthrough.values_double[passthrough_index.index] =
+            get_command(passthrough_index.name);
+          break;
+
+        default:
+          throw std::runtime_error{"Invalid data type"};
+      }
     }
   }
 
@@ -224,8 +237,20 @@ void KukaRsiHardwareInterface::setState(const RsiState& state)
   // Passthrough interfaces
   for (const auto& passthrough_index : interface_config.passthrough_state_interfaces)
   {
-    set_state(passthrough_index.name,
-              state.passthrough.values_bool[passthrough_index.index] ? 1.0 : 0.0);
+    switch (passthrough_index.type)
+    {
+      case DataType::BOOL:
+        set_state(passthrough_index.name,
+                  state.passthrough.values_bool[passthrough_index.index] ? 1.0 : 0.0);
+        break;
+
+      case DataType::DOUBLE:
+        set_state(passthrough_index.name, state.passthrough.values_double[passthrough_index.index]);
+        break;
+
+      default:
+        throw std::runtime_error{"Invalid data type"};
+    }
   }
 }
 

--- a/kuka_rsi_driver/src/rsi.cpp
+++ b/kuka_rsi_driver/src/rsi.cpp
@@ -193,9 +193,15 @@ void CartesianPose::getQuaternion(double& x, double& y, double& z, double& w) co
   w = ca * cb * cc + sa * sb * sc;
 }
 
-RsiState::RsiState()
+RsiPassthrough::RsiPassthrough(std::size_t num_bool)
+{
+  values_bool.resize(num_bool);
+}
+
+RsiState::RsiState(std::size_t num_passthrough_bool)
   : delay{0}
   , ipoc{0}
+  , passthrough{num_passthrough_bool}
 {
 }
 

--- a/kuka_rsi_driver/src/rsi.cpp
+++ b/kuka_rsi_driver/src/rsi.cpp
@@ -205,7 +205,8 @@ RsiState::RsiState(std::size_t num_passthrough_bool)
 {
 }
 
-RsiCommand::RsiCommand()
+RsiCommand::RsiCommand(std::size_t num_passthrough_bool)
+  : passthrough{num_passthrough_bool}
 {
   axis_command_pos.fill(0.0);
 }
@@ -216,6 +217,11 @@ void interpolate(const RsiCommand& c1, const RsiCommand& c2, double alpha, RsiCo
   {
     dest.axis_command_pos[i] =
       (1 - alpha) * c1.axis_command_pos[i] + alpha * c2.axis_command_pos[i];
+  }
+
+  for (std::size_t i = 0; i < c1.passthrough.values_bool.size(); ++i)
+  {
+    dest.passthrough.values_bool[i] = c1.passthrough.values_bool[i];
   }
 }
 

--- a/kuka_rsi_driver/src/rsi.cpp
+++ b/kuka_rsi_driver/src/rsi.cpp
@@ -229,10 +229,13 @@ void interpolate(const RsiCommand& c1, const RsiCommand& c2, double alpha, RsiCo
     dest.passthrough.values_double[i] =
       (1 - alpha) * c1.passthrough.values_double[i] + alpha * c2.passthrough.values_double[i];
   }
-
   for (std::size_t i = 0; i < c1.passthrough.values_bool.size(); ++i)
   {
     dest.passthrough.values_bool[i] = c1.passthrough.values_bool[i];
+  }
+  for (std::size_t i = 0; i < c1.passthrough.values_long.size(); ++i)
+  {
+    dest.passthrough.values_long[i] = c1.passthrough.values_long[i];
   }
 }
 

--- a/kuka_rsi_driver/src/rsi.cpp
+++ b/kuka_rsi_driver/src/rsi.cpp
@@ -193,20 +193,21 @@ void CartesianPose::getQuaternion(double& x, double& y, double& z, double& w) co
   w = ca * cb * cc + sa * sb * sc;
 }
 
-RsiPassthrough::RsiPassthrough(std::size_t num_bool)
+RsiPassthrough::RsiPassthrough(std::size_t num_bool, std::size_t num_double)
 {
   values_bool.resize(num_bool);
+  values_double.resize(num_double);
 }
 
-RsiState::RsiState(std::size_t num_passthrough_bool)
+RsiState::RsiState(std::size_t num_passthrough_bool, std::size_t num_passthrough_double)
   : delay{0}
   , ipoc{0}
-  , passthrough{num_passthrough_bool}
+  , passthrough{num_passthrough_bool, num_passthrough_double}
 {
 }
 
-RsiCommand::RsiCommand(std::size_t num_passthrough_bool)
-  : passthrough{num_passthrough_bool}
+RsiCommand::RsiCommand(std::size_t num_passthrough_bool, std::size_t num_passthrough_double)
+  : passthrough{num_passthrough_bool, num_passthrough_double}
 {
   axis_command_pos.fill(0.0);
 }
@@ -217,6 +218,11 @@ void interpolate(const RsiCommand& c1, const RsiCommand& c2, double alpha, RsiCo
   {
     dest.axis_command_pos[i] =
       (1 - alpha) * c1.axis_command_pos[i] + alpha * c2.axis_command_pos[i];
+  }
+  for (std::size_t i = 0; i < c1.passthrough.values_double.size(); ++i)
+  {
+    dest.passthrough.values_double[i] =
+      (1 - alpha) * c1.passthrough.values_double[i] + alpha * c2.passthrough.values_double[i];
   }
 
   for (std::size_t i = 0; i < c1.passthrough.values_bool.size(); ++i)

--- a/kuka_rsi_driver/src/rsi.cpp
+++ b/kuka_rsi_driver/src/rsi.cpp
@@ -193,21 +193,26 @@ void CartesianPose::getQuaternion(double& x, double& y, double& z, double& w) co
   w = ca * cb * cc + sa * sb * sc;
 }
 
-RsiPassthrough::RsiPassthrough(std::size_t num_bool, std::size_t num_double)
+RsiPassthrough::RsiPassthrough(std::size_t num_bool, std::size_t num_double, std::size_t num_long)
 {
   values_bool.resize(num_bool);
   values_double.resize(num_double);
+  values_long.resize(num_long);
 }
 
-RsiState::RsiState(std::size_t num_passthrough_bool, std::size_t num_passthrough_double)
+RsiState::RsiState(std::size_t num_passthrough_bool,
+                   std::size_t num_passthrough_double,
+                   std::size_t num_passthrough_long)
   : delay{0}
   , ipoc{0}
-  , passthrough{num_passthrough_bool, num_passthrough_double}
+  , passthrough{num_passthrough_bool, num_passthrough_double, num_passthrough_long}
 {
 }
 
-RsiCommand::RsiCommand(std::size_t num_passthrough_bool, std::size_t num_passthrough_double)
-  : passthrough{num_passthrough_bool, num_passthrough_double}
+RsiCommand::RsiCommand(std::size_t num_passthrough_bool,
+                       std::size_t num_passthrough_double,
+                       std::size_t num_passthrough_long)
+  : passthrough{num_passthrough_bool, num_passthrough_double, num_passthrough_long}
 {
   axis_command_pos.fill(0.0);
 }

--- a/kuka_rsi_driver/src/rsi_config.cpp
+++ b/kuka_rsi_driver/src/rsi_config.cpp
@@ -1,0 +1,174 @@
+// Copyright 2024 FZI Forschungszentrum Informatik
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/*!\file rsi_config.cpp
+ *
+ * \author  Robert Wilbrandt wilbrandt@fzi.de
+ * \date    2025-03-06
+ */
+#include "kuka_rsi_driver/rsi_config.h"
+
+#include <algorithm>
+#include <array>
+#include <fmt/format.h>
+#include <hardware_interface/types/hardware_interface_type_values.hpp>
+
+namespace kuka_rsi_driver {
+
+InterfaceConfig::InterfaceConfig(const hardware_interface::HardwareInfo& info)
+{
+  for (std::size_t i = 0; i < info.joints.size(); ++i)
+  {
+    const auto& joint = info.joints[i];
+
+    verifyComponent(joint,
+                    fmt::format("joint {}", i),
+                    {hardware_interface::HW_IF_POSITION, hardware_interface::HW_IF_EFFORT},
+                    {hardware_interface::HW_IF_POSITION});
+    m_joint_command_position_interfaces.push_back(joint.name + "/" +
+                                                  joint.command_interfaces[0].name);
+    m_joint_state_position_interfaces.push_back(joint.name + "/" + joint.state_interfaces[0].name);
+    m_joint_state_effort_interfaces.push_back(joint.name + "/" + joint.state_interfaces[1].name);
+  }
+
+  // Verify sensors
+  if (info.sensors.size() != 1)
+  {
+    throw std::runtime_error{
+      fmt::format("Expected 1 sensor element, but found %zu", info.sensors.size())};
+  }
+  verifyComponent(info.sensors[0],
+                  "tcp",
+                  {"position.x",
+                   "position.y",
+                   "position.z",
+                   "orientation.x",
+                   "orientation.y",
+                   "orientation.z",
+                   "orientation.w"},
+                  {});
+  std::transform(
+    info.sensors[0].state_interfaces.cbegin(),
+    info.sensors[0].state_interfaces.cend(),
+    std::back_inserter(m_tcp_sensor_interfaces),
+    [&](const auto& interface) { return info.sensors[0].name + '/' + interface.name; });
+
+  // Verify gpios
+  if (info.gpios.size() != 2)
+  {
+    throw std::runtime_error{
+      fmt::format("Expected 2 gpio elements, but found %zu", info.gpios.size())};
+  }
+
+  verifyComponent(info.gpios[0], "robot state", {"program_state"}, {});
+  m_robot_state_interface = info.gpios[0].name + "/" + info.gpios[0].state_interfaces[0].name;
+
+  verifyComponent(info.gpios[1], "speed scaling", {"speed_scaling_factor"}, {});
+  m_speed_scaling_interface = info.gpios[1].name + "/" + info.gpios[1].state_interfaces[0].name;
+}
+
+const std::vector<std::string>& InterfaceConfig::jointStatePositionInterfaces() const
+{
+  return m_joint_state_position_interfaces;
+}
+
+const std::vector<std::string>& InterfaceConfig::jointStateEffortInterfaces() const
+{
+  return m_joint_state_effort_interfaces;
+}
+
+const std::vector<std::string>& InterfaceConfig::jointCommandPositionInterfaces() const
+{
+  return m_joint_command_position_interfaces;
+}
+
+const std::vector<std::string>& InterfaceConfig::tcpSensorInterfaces() const
+{
+  return m_tcp_sensor_interfaces;
+}
+
+const std::string& InterfaceConfig::robotStateInterface() const
+{
+  return m_robot_state_interface;
+}
+
+const std::string& InterfaceConfig::speedScalingInterface() const
+{
+  return m_speed_scaling_interface;
+}
+
+void InterfaceConfig::verifyComponent(
+  const hardware_interface::ComponentInfo& component,
+  const std::string& component_function,
+  const std::vector<std::string>& expected_state_interfaces,
+  const std::vector<std::string>& expected_command_interfaces) const
+{
+  if (!std::equal(component.command_interfaces.cbegin(),
+                  component.command_interfaces.cend(),
+                  expected_command_interfaces.cbegin(),
+                  expected_command_interfaces.cend(),
+                  [](const auto& i1, const auto& i2) { return i1.name == i2; }))
+  {
+    std::vector<std::string> interface_names;
+    std::transform(component.command_interfaces.begin(),
+                   component.command_interfaces.end(),
+                   std::back_inserter(interface_names),
+                   [](const auto& c) { return c.name; });
+    throw std::runtime_error{
+      fmt::format("{} '{}' ({}) should have {} command interfaces [{}], found [{}]",
+                  component.type,
+                  component.name,
+                  component_function,
+                  expected_command_interfaces.size(),
+                  fmt::join(expected_command_interfaces, ", "),
+                  fmt::join(interface_names, ", "))};
+  }
+
+  if (!std::equal(component.state_interfaces.cbegin(),
+                  component.state_interfaces.cend(),
+                  expected_state_interfaces.cbegin(),
+                  expected_state_interfaces.cend(),
+                  [](const auto& i1, const auto& i2) { return i1.name == i2; }))
+  {
+    std::vector<std::string> interface_names;
+    std::transform(component.state_interfaces.begin(),
+                   component.state_interfaces.end(),
+                   std::back_inserter(interface_names),
+                   [](const auto& c) { return c.name; });
+    throw std::runtime_error{
+      fmt::format("{} '{}' ({}) should have {} state interfaces [{}], found [{}]",
+                  component.type,
+                  component.name,
+                  component_function,
+                  expected_state_interfaces.size(),
+                  fmt::join(expected_state_interfaces, ", "),
+                  fmt::join(interface_names, ", "))};
+  }
+}
+
+} // namespace kuka_rsi_driver

--- a/kuka_rsi_driver/src/rsi_config.cpp
+++ b/kuka_rsi_driver/src/rsi_config.cpp
@@ -44,6 +44,7 @@ namespace kuka_rsi_driver {
 TransmissionConfig::TransmissionConfig()
   : num_passthrough_bool{0}
   , num_passthrough_double{0}
+  , num_passthrough_long{0}
 {
 }
 
@@ -246,6 +247,11 @@ RsiConfig::parseInterfaces(std::span<const hardware_interface::InterfaceInfo> in
         type   = DataType::DOUBLE;
         type_c = 'd';
       }
+      else if (rsi_type_it->second == "long")
+      {
+        type   = DataType::LONG;
+        type_c = 'l';
+      }
       else
       {
         throw std::runtime_error{
@@ -264,6 +270,8 @@ RsiConfig::parseInterfaces(std::span<const hardware_interface::InterfaceInfo> in
           return transmission_config.num_passthrough_bool++;
         case DataType::DOUBLE:
           return transmission_config.num_passthrough_double++;
+        case DataType::LONG:
+          return transmission_config.num_passthrough_long++;
         default:
           throw std::runtime_error{"Invalid data type"};
       }

--- a/kuka_rsi_driver/src/rsi_config.cpp
+++ b/kuka_rsi_driver/src/rsi_config.cpp
@@ -40,6 +40,11 @@
 
 namespace kuka_rsi_driver {
 
+TransmissionConfig::TransmissionConfig()
+  : num_passthrough_bool{0}
+{
+}
+
 RsiConfig::RsiConfig(const hardware_interface::HardwareInfo& info)
 {
   for (std::size_t i = 0; i < info.joints.size(); ++i)
@@ -101,6 +106,11 @@ RsiConfig::RsiConfig(const hardware_interface::HardwareInfo& info)
 const InterfaceConfig& RsiConfig::interfaceConfig() const
 {
   return m_interface_config;
+}
+
+const TransmissionConfig& RsiConfig::receiveTransmissionConfig() const
+{
+  return m_receive_config;
 }
 
 void RsiConfig::verifyComponent(const hardware_interface::ComponentInfo& component,

--- a/kuka_rsi_driver/src/rsi_config.cpp
+++ b/kuka_rsi_driver/src/rsi_config.cpp
@@ -191,8 +191,16 @@ void RsiConfig::parsePassthrough(const hardware_interface::ComponentInfo& compon
 
     const auto state_index = m_receive_config.num_passthrough_bool++;
 
-    RCLCPP_INFO(m_log, "  %s.%s => S[%zu]", tag_name.c_str(), attribute_name.c_str(), state_index);
+    RCLCPP_INFO(m_log,
+                "  %s.%s => S[%zu] => %s/%s",
+                tag_name.c_str(),
+                attribute_name.c_str(),
+                state_index,
+                component.name.c_str(),
+                state_interface.name.c_str());
     tag.indices.push_back(RsiIndex{attribute_name, state_index});
+    m_interface_config.passthrough_state_interfaces.emplace_back(
+      state_index, component.name + "/" + state_interface.name);
   }
 
   m_receive_config.tags.push_back(tag);

--- a/kuka_rsi_driver/src/rsi_config.cpp
+++ b/kuka_rsi_driver/src/rsi_config.cpp
@@ -46,7 +46,17 @@ TransmissionConfig::TransmissionConfig()
 }
 
 RsiConfig::RsiConfig(const hardware_interface::HardwareInfo& info)
+  : m_sentype{"KukaRsiDriver"}
+  , m_listen_address{requiredHardwareParam(info, "listen_address")}
+  , m_listen_port{
+      static_cast<unsigned short>(std::stoi(requiredHardwareParam(info, "listen_port")))}
 {
+  if (const auto sentype_it = info.hardware_parameters.find("sentype");
+      sentype_it != info.hardware_parameters.end())
+  {
+    m_sentype = sentype_it->second;
+  }
+
   for (std::size_t i = 0; i < info.joints.size(); ++i)
   {
     const auto& joint = info.joints[i];
@@ -108,6 +118,21 @@ RsiConfig::RsiConfig(const hardware_interface::HardwareInfo& info)
   }
 }
 
+const std::string& RsiConfig::sentype() const
+{
+  return m_sentype;
+}
+
+const std::string& RsiConfig::listenAddress() const
+{
+  return m_listen_address;
+}
+
+unsigned short RsiConfig::listenPort() const
+{
+  return m_listen_port;
+}
+
 const InterfaceConfig& RsiConfig::interfaceConfig() const
 {
   return m_interface_config;
@@ -116,6 +141,19 @@ const InterfaceConfig& RsiConfig::interfaceConfig() const
 const TransmissionConfig& RsiConfig::receiveTransmissionConfig() const
 {
   return m_receive_config;
+}
+
+std::string RsiConfig::requiredHardwareParam(const hardware_interface::HardwareInfo& info,
+                                             const std::string& name) const
+{
+  if (const auto it = info.hardware_parameters.find(name); it != info.hardware_parameters.end())
+  {
+    return it->second;
+  }
+  else
+  {
+    throw std::runtime_error{fmt::format("Missing required hardware parameter {}", name)};
+  }
 }
 
 void RsiConfig::parsePassthrough(const hardware_interface::ComponentInfo& component)

--- a/kuka_rsi_driver/src/rsi_config.cpp
+++ b/kuka_rsi_driver/src/rsi_config.cpp
@@ -61,7 +61,13 @@ RsiConfig::RsiConfig(const hardware_interface::HardwareInfo& info, rclcpp::Logge
     m_sentype = sentype_it->second;
   }
 
-  for (std::size_t i = 0; i < info.joints.size(); ++i)
+  // Verify joints
+  if (info.joints.size() < 6)
+  {
+    throw std::runtime_error{
+      fmt::format("Expected at least 6 joints, but found {}", info.joints.size())};
+  }
+  for (std::size_t i = 0; i < 6; ++i)
   {
     const auto& joint = info.joints[i];
 
@@ -78,12 +84,16 @@ RsiConfig::RsiConfig(const hardware_interface::HardwareInfo& info, rclcpp::Logge
     m_interface_config.joint_effort_state_interfaces.push_back(joint.name + "/" +
                                                                joint.state_interfaces[1].name);
   }
+  for (std::size_t i = 6; i < info.joints.size(); ++i)
+  {
+    parsePassthrough(info.joints[i]);
+  }
 
   // Verify sensors
   if (info.sensors.size() < 1)
   {
     throw std::runtime_error{
-      fmt::format("Expected at least 1 sensor element, but found %zu", info.sensors.size())};
+      fmt::format("Expected at least 1 sensor element, but found {}", info.sensors.size())};
   }
   verifyComponent(info.sensors[0],
                   "tcp",

--- a/kuka_rsi_driver/src/rsi_factory.cpp
+++ b/kuka_rsi_driver/src/rsi_factory.cpp
@@ -70,6 +70,11 @@ RsiFactory::RsiFactory(std::shared_ptr<RsiConfig> config, std::size_t cyclic_buf
 
 RsiCommand RsiFactory::createCommand() const
 {
+  if (!m_rsi_config)
+  {
+    return RsiCommand{0, 0};
+  }
+
   return RsiCommand{m_rsi_config->sendTransmissionConfig().num_passthrough_bool,
                     m_rsi_config->sendTransmissionConfig().num_passthrough_double};
 }

--- a/kuka_rsi_driver/src/rsi_factory.cpp
+++ b/kuka_rsi_driver/src/rsi_factory.cpp
@@ -44,8 +44,8 @@ RsiFactory::RsiFactory(std::size_t cyclic_buf_size)
 
   for (std::size_t i = 0; i < cyclic_buf_size; ++i)
   {
-    m_cmd_buf.emplace_back(std::make_shared<RsiCommand>(0, 0));
-    m_state_buf.emplace_back(std::make_shared<RsiState>(0, 0));
+    m_cmd_buf.emplace_back(std::make_shared<RsiCommand>(0, 0, 0));
+    m_state_buf.emplace_back(std::make_shared<RsiState>(0, 0, 0));
   }
 }
 
@@ -61,10 +61,12 @@ RsiFactory::RsiFactory(std::shared_ptr<RsiConfig> config, std::size_t cyclic_buf
   {
     m_cmd_buf.emplace_back(
       std::make_shared<RsiCommand>(m_rsi_config->sendTransmissionConfig().num_passthrough_bool,
-                                   m_rsi_config->sendTransmissionConfig().num_passthrough_double));
+                                   m_rsi_config->sendTransmissionConfig().num_passthrough_double,
+                                   m_rsi_config->sendTransmissionConfig().num_passthrough_long));
     m_state_buf.emplace_back(
       std::make_shared<RsiState>(m_rsi_config->receiveTransmissionConfig().num_passthrough_bool,
-                                 m_rsi_config->receiveTransmissionConfig().num_passthrough_double));
+                                 m_rsi_config->receiveTransmissionConfig().num_passthrough_double,
+                                 m_rsi_config->receiveTransmissionConfig().num_passthrough_long));
   }
 }
 
@@ -72,11 +74,12 @@ RsiCommand RsiFactory::createCommand() const
 {
   if (!m_rsi_config)
   {
-    return RsiCommand{0, 0};
+    return RsiCommand{0, 0, 0};
   }
 
   return RsiCommand{m_rsi_config->sendTransmissionConfig().num_passthrough_bool,
-                    m_rsi_config->sendTransmissionConfig().num_passthrough_double};
+                    m_rsi_config->sendTransmissionConfig().num_passthrough_double,
+                    m_rsi_config->sendTransmissionConfig().num_passthrough_long};
 }
 
 std::shared_ptr<RsiCommand> RsiFactory::createCyclicCommand()

--- a/kuka_rsi_driver/src/rsi_factory.cpp
+++ b/kuka_rsi_driver/src/rsi_factory.cpp
@@ -89,7 +89,6 @@ std::shared_ptr<RsiState> RsiFactory::createCyclicState()
 
   if (state.use_count() != 1)
   {
-    std::cerr << m_state_i << " - " << state.use_count() << std::endl;
     throw std::runtime_error{"Cyclic states exhausted"};
   }
 

--- a/kuka_rsi_driver/src/rsi_factory.cpp
+++ b/kuka_rsi_driver/src/rsi_factory.cpp
@@ -44,8 +44,8 @@ RsiFactory::RsiFactory(std::size_t cyclic_buf_size)
 
   for (std::size_t i = 0; i < cyclic_buf_size; ++i)
   {
-    m_cmd_buf.emplace_back(std::make_shared<RsiCommand>(0));
-    m_state_buf.emplace_back(std::make_shared<RsiState>(0));
+    m_cmd_buf.emplace_back(std::make_shared<RsiCommand>(0, 0));
+    m_state_buf.emplace_back(std::make_shared<RsiState>(0, 0));
   }
 }
 
@@ -60,15 +60,18 @@ RsiFactory::RsiFactory(std::shared_ptr<RsiConfig> config, std::size_t cyclic_buf
   for (std::size_t i = 0; i < cyclic_buf_size; ++i)
   {
     m_cmd_buf.emplace_back(
-      std::make_shared<RsiCommand>(m_rsi_config->sendTransmissionConfig().num_passthrough_bool));
+      std::make_shared<RsiCommand>(m_rsi_config->sendTransmissionConfig().num_passthrough_bool,
+                                   m_rsi_config->sendTransmissionConfig().num_passthrough_double));
     m_state_buf.emplace_back(
-      std::make_shared<RsiState>(m_rsi_config->receiveTransmissionConfig().num_passthrough_bool));
+      std::make_shared<RsiState>(m_rsi_config->receiveTransmissionConfig().num_passthrough_bool,
+                                 m_rsi_config->receiveTransmissionConfig().num_passthrough_double));
   }
 }
 
 RsiCommand RsiFactory::createCommand() const
 {
-  return RsiCommand{m_rsi_config->sendTransmissionConfig().num_passthrough_bool};
+  return RsiCommand{m_rsi_config->sendTransmissionConfig().num_passthrough_bool,
+                    m_rsi_config->sendTransmissionConfig().num_passthrough_double};
 }
 
 std::shared_ptr<RsiCommand> RsiFactory::createCyclicCommand()

--- a/kuka_rsi_driver/src/rsi_factory.cpp
+++ b/kuka_rsi_driver/src/rsi_factory.cpp
@@ -33,8 +33,6 @@
  */
 #include "kuka_rsi_driver/rsi_factory.h"
 
-#include <iostream>
-
 namespace kuka_rsi_driver {
 
 RsiFactory::RsiFactory(std::size_t cyclic_buf_size)

--- a/kuka_rsi_driver/src/rsi_factory.cpp
+++ b/kuka_rsi_driver/src/rsi_factory.cpp
@@ -47,7 +47,22 @@ RsiFactory::RsiFactory(std::size_t cyclic_buf_size)
   for (std::size_t i = 0; i < cyclic_buf_size; ++i)
   {
     m_cmd_buf.emplace_back(std::make_shared<RsiCommand>());
-    m_state_buf.emplace_back(std::make_shared<RsiState>());
+    m_state_buf.emplace_back(std::make_shared<RsiState>(0));
+  }
+}
+
+RsiFactory::RsiFactory(const RsiConfig& config, std::size_t cyclic_buf_size)
+  : m_cmd_i{0}
+  , m_state_i{0}
+{
+  m_cmd_buf.reserve(cyclic_buf_size);
+  m_state_buf.reserve(cyclic_buf_size);
+
+  for (std::size_t i = 0; i < cyclic_buf_size; ++i)
+  {
+    m_cmd_buf.emplace_back(std::make_shared<RsiCommand>());
+    m_state_buf.emplace_back(
+      std::make_shared<RsiState>(config.receiveTransmissionConfig().num_passthrough_bool));
   }
 }
 

--- a/kuka_rsi_driver/src/rsi_factory.cpp
+++ b/kuka_rsi_driver/src/rsi_factory.cpp
@@ -44,13 +44,14 @@ RsiFactory::RsiFactory(std::size_t cyclic_buf_size)
 
   for (std::size_t i = 0; i < cyclic_buf_size; ++i)
   {
-    m_cmd_buf.emplace_back(std::make_shared<RsiCommand>());
+    m_cmd_buf.emplace_back(std::make_shared<RsiCommand>(0));
     m_state_buf.emplace_back(std::make_shared<RsiState>(0));
   }
 }
 
-RsiFactory::RsiFactory(const RsiConfig& config, std::size_t cyclic_buf_size)
-  : m_cmd_i{0}
+RsiFactory::RsiFactory(std::shared_ptr<RsiConfig> config, std::size_t cyclic_buf_size)
+  : m_rsi_config{std::move(config)}
+  , m_cmd_i{0}
   , m_state_i{0}
 {
   m_cmd_buf.reserve(cyclic_buf_size);
@@ -58,15 +59,16 @@ RsiFactory::RsiFactory(const RsiConfig& config, std::size_t cyclic_buf_size)
 
   for (std::size_t i = 0; i < cyclic_buf_size; ++i)
   {
-    m_cmd_buf.emplace_back(std::make_shared<RsiCommand>());
+    m_cmd_buf.emplace_back(
+      std::make_shared<RsiCommand>(m_rsi_config->sendTransmissionConfig().num_passthrough_bool));
     m_state_buf.emplace_back(
-      std::make_shared<RsiState>(config.receiveTransmissionConfig().num_passthrough_bool));
+      std::make_shared<RsiState>(m_rsi_config->receiveTransmissionConfig().num_passthrough_bool));
   }
 }
 
 RsiCommand RsiFactory::createCommand() const
 {
-  return RsiCommand{};
+  return RsiCommand{m_rsi_config->sendTransmissionConfig().num_passthrough_bool};
 }
 
 std::shared_ptr<RsiCommand> RsiFactory::createCyclicCommand()

--- a/kuka_rsi_driver/src/rsi_parser.cpp
+++ b/kuka_rsi_driver/src/rsi_parser.cpp
@@ -408,6 +408,12 @@ RsiParser::RsiParser(const TransmissionConfig& config,
               break;
             }
 
+            case DataType::LONG: {
+              const auto v = parseNumber<std::uint64_t>(attributes[i]);
+              m_rsi_state->passthrough.values_long[tag.indices[i].index] = v;
+              break;
+            }
+
             default:
               throw std::runtime_error{"Invalid data type"};
           }

--- a/kuka_rsi_driver/src/rsi_writer.cpp
+++ b/kuka_rsi_driver/src/rsi_writer.cpp
@@ -139,6 +139,10 @@ std::size_t RsiWriter::writeCommand(const RsiCommand& cmd, std::size_t ipoc, std
           m_writer.writeNumber(cmd.passthrough.values_double[index.index]);
           break;
 
+        case DataType::LONG:
+          m_writer.writeNumber(cmd.passthrough.values_long[index.index]);
+          break;
+
         default:
           throw std::runtime_error{"Invalid data type"};
       }

--- a/kuka_rsi_driver/src/rsi_writer.cpp
+++ b/kuka_rsi_driver/src/rsi_writer.cpp
@@ -128,7 +128,21 @@ std::size_t RsiWriter::writeCommand(const RsiCommand& cmd, std::size_t ipoc, std
     {
       m_writer.writeText(index.name);
       m_writer.writeText("=\"");
-      m_writer.writeText(cmd.passthrough.values_bool[index.index] ? "1" : "0");
+
+      switch (index.type)
+      {
+        case DataType::BOOL:
+          m_writer.writeText(cmd.passthrough.values_bool[index.index] ? "1" : "0");
+          break;
+
+        case DataType::DOUBLE:
+          m_writer.writeNumber(cmd.passthrough.values_double[index.index]);
+          break;
+
+        default:
+          throw std::runtime_error{"Invalid data type"};
+      }
+
       m_writer.writeText("\" ");
     }
   }

--- a/kuka_rsi_driver/src/rsi_writer.cpp
+++ b/kuka_rsi_driver/src/rsi_writer.cpp
@@ -90,8 +90,12 @@ void TextWriter::writeNumber(double v)
   m_head = ptr;
 }
 
-RsiWriter::RsiWriter(const std::string& sentype, rclcpp::Logger log, std::size_t buf_size)
+RsiWriter::RsiWriter(const std::string& sentype,
+                     const TransmissionConfig& config,
+                     rclcpp::Logger log,
+                     std::size_t buf_size)
   : m_log{std::move(log)}
+  , m_config{config}
   , m_sentype{sentype}
   , m_writer{m_log}
 {
@@ -112,6 +116,21 @@ std::size_t RsiWriter::writeCommand(const RsiCommand& cmd, std::size_t ipoc, std
     m_writer.writeText("=\"");
     m_writer.writeNumber(cmd.axis_command_pos[i]);
     m_writer.writeText("\" ");
+  }
+
+  for (const auto& tag : m_config.tags)
+  {
+    m_writer.writeText("/><");
+    m_writer.writeText(tag.name);
+    m_writer.writeText(" ");
+
+    for (const auto& index : tag.indices)
+    {
+      m_writer.writeText(index.name);
+      m_writer.writeText("=\"");
+      m_writer.writeText(cmd.passthrough.values_bool[index.index] ? "1" : "0");
+      m_writer.writeText("\" ");
+    }
   }
 
   m_writer.writeText("/><IPOC>");

--- a/kuka_rsi_driver/test/rsi_parser.cpp
+++ b/kuka_rsi_driver/test/rsi_parser.cpp
@@ -150,7 +150,7 @@ TEST(RsiParser, ParseTestXml)
   const auto log = rclcpp::get_logger("rsi_parser");
 
   RsiFactory rsi_factory;
-  RsiParser rsi_parser{log, &rsi_factory};
+  RsiParser rsi_parser{TransmissionConfig{}, &rsi_factory, log};
 
   const auto buf = rsi_parser.buffer();
   ASSERT_GE(buf.size(), test_xml.size());

--- a/kuka_rsi_driver/test/rsi_writer.cpp
+++ b/kuka_rsi_driver/test/rsi_writer.cpp
@@ -41,10 +41,10 @@ TEST(RsiWriter, WriteTestXml)
 {
   const auto log = rclcpp::get_logger("rsi_writer");
 
-  RsiWriter writer{"TestSenType", log};
+  RsiWriter writer{"TestSenType", TransmissionConfig{}, log};
 
   // Create test command
-  RsiCommand cmd;
+  RsiCommand cmd{0};
   for (std::size_t i = 0; i < cmd.axis_command_pos.size(); ++i)
   {
     cmd.axis_command_pos[i] = i;

--- a/kuka_rsi_driver/test/rsi_writer.cpp
+++ b/kuka_rsi_driver/test/rsi_writer.cpp
@@ -44,7 +44,7 @@ TEST(RsiWriter, WriteTestXml)
   RsiWriter writer{"TestSenType", TransmissionConfig{}, log};
 
   // Create test command
-  RsiCommand cmd{0, 0};
+  RsiCommand cmd{0, 0, 0};
   for (std::size_t i = 0; i < cmd.axis_command_pos.size(); ++i)
   {
     cmd.axis_command_pos[i] = i;

--- a/kuka_rsi_driver/test/rsi_writer.cpp
+++ b/kuka_rsi_driver/test/rsi_writer.cpp
@@ -44,7 +44,7 @@ TEST(RsiWriter, WriteTestXml)
   RsiWriter writer{"TestSenType", TransmissionConfig{}, log};
 
   // Create test command
-  RsiCommand cmd{0};
+  RsiCommand cmd{0, 0};
   for (std::size_t i = 0; i < cmd.axis_command_pos.size(); ++i)
   {
     cmd.axis_command_pos[i] = i;

--- a/kuka_rsi_driver/urdf/kuka_rsi_driver.ros2_control.xacro
+++ b/kuka_rsi_driver/urdf/kuka_rsi_driver.ros2_control.xacro
@@ -80,6 +80,18 @@
         </state_interface>
       </gpio>
 
+      <gpio name="qcs">
+        <param name="rsi_name">QCS</param>
+
+        <state_interface name="sensor_unlocked">
+          <param name="rsi_name">Sensor_Unlocked</param>
+        </state_interface>
+
+        <state_interface name="sensor_locked">
+          <param name="rsi_name">Sensor_Locked</param>
+        </state_interface>
+      </gpio>
+
     </ros2_control>
   </xacro:macro>
 

--- a/kuka_rsi_driver/urdf/kuka_rsi_driver.ros2_control.xacro
+++ b/kuka_rsi_driver/urdf/kuka_rsi_driver.ros2_control.xacro
@@ -23,6 +23,32 @@
     rsi_listen_ip
     rsi_listen_port:=49152
     ">
+    <xacro:kuka_rsi_driver_control_passthrough
+      name="${name}"
+      prefix="${prefix}"
+      rw_rate="${rw_rate}"
+      use_mock_hardware="${use_mock_hardware}"
+      mock_gpio_commands="${mock_gpio_commands}"
+      mock_sensor_commands="${mock_sensor_commands}"
+      initial_positions="${initial_positions}"
+      rsi_listen_ip="${rsi_listen_ip}"
+      rsi_listen_port="${rsi_listen_port}">
+      <empty />
+    </xacro:kuka_rsi_driver_control_passthrough>
+  </xacro:macro>
+
+  <xacro:macro name="kuka_rsi_driver_control_passthrough" params="
+    name
+    prefix
+    rw_rate:=0
+    use_mock_hardware:=false
+    mock_gpio_commands:=false
+    mock_sensor_commands:=false
+    initial_positions:=${dict(joint_a1=0.0,joint_a2=0.0,joint_a3=0.0,joint_a4=0.0,joint_a5=0.0,joint_a6=0.0)}
+    rsi_listen_ip
+    rsi_listen_port:=49152
+    **passthrough
+    ">
     <ros2_control name="${name}" type="system" rw_rate="${rw_rate}">
       <hardware>
         <xacro:if value="${use_mock_hardware}">
@@ -80,17 +106,7 @@
         </state_interface>
       </gpio>
 
-      <gpio name="qcs">
-        <param name="rsi_name">QCS</param>
-
-        <state_interface name="sensor_unlocked">
-          <param name="rsi_name">Sensor_Unlocked</param>
-        </state_interface>
-
-        <state_interface name="sensor_locked">
-          <param name="rsi_name">Sensor_Locked</param>
-        </state_interface>
-      </gpio>
+      <xacro:insert_block name="passthrough" />
 
     </ros2_control>
   </xacro:macro>


### PR DESCRIPTION
This PR enables the integration of additional hardware components by forwarding state- and command interfaces directly to RSI elements. After configuring the desired components in Kuka.WorkVisual and defining the RSI signals, they only need to be defined in the URDF using the new `<kuka_rsi_driver_control_passthrough />` tag to make them available as interfaces.