### PR TITLE
Fix lifecycle transitions

### DIFF
--- a/kuka_rsi_driver/include/kuka_rsi_driver/hardware_interface.h
+++ b/kuka_rsi_driver/include/kuka_rsi_driver/hardware_interface.h
@@ -52,7 +52,7 @@ class KukaRsiHardwareInterface : public hardware_interface::SystemInterface
 {
 public:
   hardware_interface::CallbackReturn
-  on_init(const hardware_interface::HardwareInfo& system_info) override;
+  on_init(const hardware_interface::HardwareComponentInterfaceParams& params) override;
   hardware_interface::CallbackReturn
   on_cleanup(const rclcpp_lifecycle::State& previous_state) override;
 

--- a/kuka_rsi_driver/src/control_thread.cpp
+++ b/kuka_rsi_driver/src/control_thread.cpp
@@ -77,6 +77,7 @@ void ControlThread::start()
 void ControlThread::stop()
 {
   m_thread_stop.store(true);
+  m_thread.join();
 
   RCLCPP_INFO(m_log, "Control thread stopped");
 }

--- a/kuka_rsi_driver/src/hardware_interface.cpp
+++ b/kuka_rsi_driver/src/hardware_interface.cpp
@@ -50,10 +50,10 @@ constexpr std::array TCP_SENSOR_STATE_INTERFACES = {"position.x",
 
 namespace kuka_rsi_driver {
 
-hardware_interface::CallbackReturn
-KukaRsiHardwareInterface::on_init(const hardware_interface::HardwareInfo& info)
+hardware_interface::CallbackReturn KukaRsiHardwareInterface::on_init(
+  const hardware_interface::HardwareComponentInterfaceParams& params)
 {
-  if (hardware_interface::SystemInterface::on_init(info) !=
+  if (hardware_interface::SystemInterface::on_init(params) !=
       hardware_interface::CallbackReturn::SUCCESS)
   {
     return hardware_interface::CallbackReturn::ERROR;


### PR DESCRIPTION
This should now allow completely restarting the communication loop and remove warnings about deprecated controller_manager signatures.